### PR TITLE
SubjectAtName support

### DIFF
--- a/src/Cross/SqueakSSL.h
+++ b/src/Cross/SqueakSSL.h
@@ -59,6 +59,7 @@
 #define SQSSL_PROP_PEERNAME 0
 #define SQSSL_PROP_CERTNAME 1
 #define SQSSL_PROP_SERVERNAME 2
+#define SQSSL_PROP_SUBJECTALTNAMEDNS 3
 
 /* sqCreateSSL: Creates a new SSL instance.
 	Arguments: None.


### PR DESCRIPTION
- Expose the DNS names from the certificate's SubjectAltName extension to the image via the SQSSL_PROP_SUBJECTALTNAMEDNS string parameter (3).
- Disable SSLv2 and SSLv3, because they are both broken.

The above two should probably be added to sqAcceptSSL too.
- Use strndup for all string copying.
- Added some type casts to avoid compiler warnings.
